### PR TITLE
ハイアンドローのトップ画面にルールを表示させる　fix #265

### DIFF
--- a/app/src/main/java/com/itomakiweb/android/bank/pages/HighAndLowActivity.kt
+++ b/app/src/main/java/com/itomakiweb/android/bank/pages/HighAndLowActivity.kt
@@ -27,9 +27,11 @@ class HighAndLowActivity : AppCompatActivity() {
             }
         }
 
+        /*
         toHighAndLowRule.setOnClickListener {
             setRuleFragment()
         }
+         */
     }
 
     fun setTopFragment() {

--- a/app/src/main/res/layout/activity_high_and_low.xml
+++ b/app/src/main/res/layout/activity_high_and_low.xml
@@ -36,6 +36,7 @@
                 android:textSize="24sp"
                 android:textStyle="bold" />
 
+            <!--
             <ImageButton
                 android:id="@+id/toHighAndLowRule"
                 android:layout_width="wrap_content"
@@ -43,6 +44,7 @@
                 android:layout_weight="1"
                 android:contentDescription="@string/help"
                 app:srcCompat="@android:drawable/ic_menu_help" />
+            -->
 
             <Button
                 android:id="@+id/back"

--- a/app/src/main/res/layout/fragment_high_and_low_top.xml
+++ b/app/src/main/res/layout/fragment_high_and_low_top.xml
@@ -1,24 +1,38 @@
 <?xml version="1.0" encoding="utf-8"?>
-<TableLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:layout_margin="16dp"
     android:gravity="center"
+    android:orientation="vertical"
     tools:context=".pages.MainMenuFragment">
 
-    <TableRow
+    <Button
+        android:id="@+id/toHighAndLowGame"
+        style="@style/Widget.AppCompat.Button.Colored"
+        android:layout_width="144dp"
+        android:layout_height="144dp"
+        android:layout_marginBottom="16dp"
+        android:text="@string/newGame" />
+
+    <TextView
+        android:id="@+id/textView3"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:gravity="center">
+        android:layout_height="wrap_content"
+        android:text="@string/highAndLowRule01" />
 
-        <Button
-            android:id="@+id/toHighAndLowGame"
-            style="@style/Widget.AppCompat.Button.Colored"
-            android:layout_width="144dp"
-            android:layout_height="144dp"
-            android:text="@string/toHighAndLow" />
+    <TextView
+        android:id="@+id/textView4"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/highAndLowRule02" />
 
-    </TableRow>
+    <TextView
+        android:id="@+id/textView5"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/highAndLowRule03" />
 
-</TableLayout>
+</LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,4 +42,8 @@
     <string name="back">戻る</string>
     <string name="resultFragmentTitle">RESULT</string>
     <string name="help">ルール表示</string>
+    <string name="newGame">ゲームをはじめる</string>
+    <string name="highAndLowRule01">ディーラーカードが7より上か下かを予想する。</string>
+    <string name="highAndLowRule02">上だと予想するなら「High」を押し、</string>
+    <string name="highAndLowRule03">下だと予想するなら「Low」を押す。</string>
 </resources>


### PR DESCRIPTION
ルールボタンはコメントアウトし、ルールフラグメントは表示させず。
ハイアンドローのタイトル下にルールを３行にわけて表示させる。
レイアウトの変更もした。