### PR TITLE
表示の揺れ、文言の不統一を実装　fix #259

### DIFF
--- a/app/src/main/java/com/itomakiweb/android/bank/pages/HighAndLowGameFragment.kt
+++ b/app/src/main/java/com/itomakiweb/android/bank/pages/HighAndLowGameFragment.kt
@@ -29,12 +29,17 @@ class HighAndLowGameFragment : Fragment() {
         return inflater.inflate(R.layout.fragment_high_and_low_game, container, false)
     }
 
-    fun changeCards(): Card {
+    fun setDrawCardImage(): Card {
         val pickCard = deck.draw()
         val resId = resources.getIdentifier(pickCard.drawable,"drawable","com.itomakiweb.android.bank")
         drawCard.setImageResource(resId)
         return pickCard
     }
+
+    fun unsetDrawCardImage() {
+        drawCard.setImageResource(R.drawable.card_blank)
+    }
+
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/app/src/main/java/com/itomakiweb/android/bank/pages/HighAndLowPlayFragment.kt
+++ b/app/src/main/java/com/itomakiweb/android/bank/pages/HighAndLowPlayFragment.kt
@@ -54,6 +54,11 @@ class HighAndLowPlayFragment : Fragment() {
         highAndLowGameCount()
     }
 
+    override fun onStart() {
+        super.onStart()
+        (parentFragment as HighAndLowGameFragment).unsetDrawCardImage()
+    }
+
     fun highAndLowGameCount() {
         val currentUser = auth.currentUser!!
 

--- a/app/src/main/java/com/itomakiweb/android/bank/pages/HighAndLowResultFragment.kt
+++ b/app/src/main/java/com/itomakiweb/android/bank/pages/HighAndLowResultFragment.kt
@@ -83,7 +83,7 @@ class HighAndLowResultFragment : Fragment() {
         val deck = DeckOfCards()
         val you = You()
         val highAndLowClass = HighAndLow(deck, you)
-        val pickCard = (parentFragment as HighAndLowGameFragment).changeCards()
+        val pickCard = (parentFragment as HighAndLowGameFragment).setDrawCardImage()
         val highOrLow = when(isHigh){
             true -> HighAndLowCall.HIGH
             else -> HighAndLowCall.LOW

--- a/app/src/main/res/layout/activity_high_and_low.xml
+++ b/app/src/main/res/layout/activity_high_and_low.xml
@@ -5,7 +5,7 @@
     android:id="@+id/layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#087A0D"
+    android:background="#12DD1B"
     tools:context=".pages.HighAndLowActivity">
 
     <LinearLayout

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">BANK</string>
+    <string name="app_name">Bank it!</string>
     <string name="mainTitle"></string>
     <string name="nameIkki">ikki</string>
     <string name="nameKazucharo">kazucharo</string>


### PR DESCRIPTION
背景色を明るい緑に変更、
NEXTボタン後にカードを未表示へと変更、
stringのBANKをBank it!に変更

https://paiza.io/projects/CHJL79Szvp6xftqsyXSDow