### PR TITLE
・result画面で「you win」が必ず先に表示される　ほか

### DIFF
--- a/app/src/main/res/layout/fragment_high_and_low_result.xml
+++ b/app/src/main/res/layout/fragment_high_and_low_result.xml
@@ -16,14 +16,13 @@
         <TextView
             android:id="@+id/resultText"
             android:layout_width="match_parent"
-            android:layout_height="0dp"
+            android:layout_height="40dp"
             android:layout_marginLeft="8dp"
             android:layout_marginTop="8dp"
             android:layout_marginRight="8dp"
             android:layout_weight="1"
             android:background="@android:color/background_light"
             android:gravity="center|center_vertical"
-            android:text="@string/resultWin"
             android:textColor="@android:color/holo_red_dark"
             android:textSize="18sp"
             android:textStyle="bold" />
@@ -38,7 +37,6 @@
             android:layout_weight="1"
             android:background="@android:color/background_light"
             android:gravity="center"
-            android:text="@string/resultMoney"
             android:textAlignment="center"
             android:textColor="@android:color/black"
             android:textSize="18sp"


### PR DESCRIPTION
・「next」「back」のボタンが大きい
・「HIGH」や「LOW」を選択した時の読み込み中、画面中央に「MONEY＋％１＄ｄ」と表示されてしまう
問題を解決
fix #339
fix #330
fix #328