### PR TITLE
add close milestone and update issue

### DIFF
--- a/tools/gas-main.js
+++ b/tools/gas-main.js
@@ -236,7 +236,7 @@ function updateIssueAndCloseMilestone() {
 - 今週のMilestoneをクローズしました\n\
   - ${currentMilestoneUrl}\n\
 - OPENなクエストは、次週のMilestoneへ移行しました\n\
-- 出来そうなクエストがあればチャレンジしてみましょう！Lets try it!\n\
+- 出来そうなクエストがあればチャレンジしてみましょう！Let\'s try it!\n\
   - ${nextMilestoneUrl}\n\
 - 以下から自動送信\n\
   - ${configs.URL_GAS}\n\
@@ -286,7 +286,8 @@ function fetchRepositoryInfoFromGithub() {
  *
  * @param {string[]} OPEN/CLOSED
  * @param {string} ASC: 昇順/DESC: 降順
- * @return {Object} Milestone
+ * @param {int} 先頭からの参照数
+ * @return {Object} レスポンスJSON
  */
 function fetchMilestonesFromGithub(states, direction, first) {
   const configs = getConfigs()
@@ -344,8 +345,7 @@ function fetchOpenIssueFromMilestone(number) {
  *
  * @see https://developer.github.com/v4/mutation/updateissue/
  *
- * @param {String} IssueID
- * @param {String} MilestoneID
+ * @param {Object} リクエスト内容
  * @return {Object} レスポンスJSON
  */
 function updateIssueInGithub(input) {


### PR DESCRIPTION
期限が直近であるマイルストーンをクローズし、その中のOPENなIssueを次期のマイルストーンへ移行させ、内容をSlackへ投稿する機能を実装しました。
configsを以下のように変更したテスト環境下では問題なく動作しました。
トリガーの設定はしておりません。
お時間がある時で構いませんので、レビューお願いします。

    GITHUB_OWNER: 'tanukinoyu',
    GITHUB_REPOSITORY: 'test',
    GITHUB_REPOSITORY_ID: 'MDEwOlJlcG9zaXRvcnkxNjE4MjE5NDg=',
    GITHUB_TODO_ASSIGNEE_IDS: [
      'MDQ6VXNlcjQ1MDA2Njgz', // tanukinoyu
    ],
    GITHUB_TODO_LABEL_IDS: [
      'MDU6TGFiZWwxNjE1ODYwNTc0', // -priority: 5
      'MDU6TGFiZWwxNjE1ODY0MDA4', // cost-pre: 3
    ],
    GITHUB_TODO_PROJECT_IDS: [
      'MDc6UHJvamVjdDM4MjczNzk=', // Quest
    ],

    SLACK_CHANNEL: 'GSHAB39EF', // gas-test
